### PR TITLE
Add column for week number #90

### DIFF
--- a/opendata/doc.yml
+++ b/opendata/doc.yml
@@ -373,9 +373,16 @@ components:
           type: string
           description: Le mois de l'opération en français. La date de référence est la date de réception de l'alerte au fuseau horaire du CROSS coordinateur.
           example: Septembre
+        semaine:
+          type: integer
+          format: int32
+          description: La semaine de l'opération, au format ISO8601. La date de référence est la date de réception de l'alerte au fuseau horaire du CROSS coordinateur.
+          example: 22
+          minimum: 1
+          maximum: 53
         numero_semaine:
           type: string
-          description: La semaine de l'opération, au format ISO8601. La date de référence est la date de réception de l'alerte au fuseau horaire du CROSS coordinateur.
+          description: La semaine et l'année de l'opération, au format ISO8601. La date de référence est la date de réception de l'alerte au fuseau horaire du CROSS coordinateur.
           example: 2018-22
         jour_semaine:
           type: string

--- a/opendata/doc.yml
+++ b/opendata/doc.yml
@@ -380,7 +380,7 @@ components:
           example: 22
           minimum: 1
           maximum: 53
-        numero_semaine:
+        annee_semaine:
           type: string
           description: La semaine et l'année de l'opération, au format ISO8601. La date de référence est la date de réception de l'alerte au fuseau horaire du CROSS coordinateur.
           example: 2018-22

--- a/opendata/sql/insert_operations_stats.sql
+++ b/opendata/sql/insert_operations_stats.sql
@@ -9,7 +9,7 @@ select
   extract(day from o.date_heure_reception_alerte at time zone o.fuseau_horaire) jour,
   '' mois_texte,
   to_char(o.date_heure_reception_alerte at time zone o.fuseau_horaire, 'IW')::int semaine,
-  to_char(o.date_heure_reception_alerte at time zone o.fuseau_horaire, 'IYYY-IW') numero_semaine,
+  to_char(o.date_heure_reception_alerte at time zone o.fuseau_horaire, 'IYYY-IW') annee_semaine,
   extract(isodow from o.date_heure_reception_alerte at time zone o.fuseau_horaire)::text jour_semaine,
   extract(isodow from o.date_heure_reception_alerte at time zone o.fuseau_horaire) in (6, 7) est_weekend,
   false est_jour_ferie,

--- a/opendata/sql/insert_operations_stats.sql
+++ b/opendata/sql/insert_operations_stats.sql
@@ -8,6 +8,7 @@ select
   extract(month from o.date_heure_reception_alerte at time zone o.fuseau_horaire) mois,
   extract(day from o.date_heure_reception_alerte at time zone o.fuseau_horaire) jour,
   '' mois_texte,
+  to_char(o.date_heure_reception_alerte at time zone o.fuseau_horaire, 'IW')::int semaine,
   to_char(o.date_heure_reception_alerte at time zone o.fuseau_horaire, 'IYYY-IW') numero_semaine,
   extract(isodow from o.date_heure_reception_alerte at time zone o.fuseau_horaire)::text jour_semaine,
   extract(isodow from o.date_heure_reception_alerte at time zone o.fuseau_horaire) in (6, 7) est_weekend,

--- a/opendata/sql/schema.sql
+++ b/opendata/sql/schema.sql
@@ -110,7 +110,7 @@ CREATE TABLE public.operations_stats (
     "jour" smallint not null,
     "mois_texte" varchar(10) not null,
     "semaine" smallint not null,
-    "numero_semaine" varchar(7) not null,
+    "annee_semaine" varchar(7) not null,
     "jour_semaine" varchar(8) not null,
     "est_weekend" boolean not null,
     "est_jour_ferie" boolean not null,

--- a/opendata/sql/schema.sql
+++ b/opendata/sql/schema.sql
@@ -109,6 +109,7 @@ CREATE TABLE public.operations_stats (
     "mois" smallint not null,
     "jour" smallint not null,
     "mois_texte" varchar(10) not null,
+    "semaine" smallint not null,
     "numero_semaine" varchar(7) not null,
     "jour_semaine" varchar(8) not null,
     "est_weekend" boolean not null,


### PR DESCRIPTION
Ça nous fait 2 colonnes très proches : 
- `semaine` : par exemple `22`
- `numero_semaine` : par exemple `2018-22`

J'aime pas les noms mais ce serait embêtant de changer le nom historique `numero_semaine`. Tu as une idée ?